### PR TITLE
use sass helper method for asset url

### DIFF
--- a/lib/voltron/svg.rb
+++ b/lib/voltron/svg.rb
@@ -11,7 +11,11 @@ module Voltron
       def svg_icon(source, options={})
         tag = Voltron::Svg::Tag.new(source.value, { extension: :svg }.merge(map_options(options)))
 
-        ::Sass::Script::String.new "url(\"#{tag.image_path}\");\nbackground-image: url(\"#{tag.svg_path}\"), linear-gradient(transparent, transparent);\nbackground-size: #{tag.width}px #{tag.height}px"
+        ::Sass::Script::String.new [
+          "#{asset_url(tag.sass_image_name)};",
+          "background-image: #{asset_url(tag.sass_svg_name)}, linear-gradient(transparent, transparent);",
+          "background-size: #{tag.width}px #{tag.height}px"
+        ].join("\n")
       end
 
       def map_options(options={})

--- a/lib/voltron/svg/tag.rb
+++ b/lib/voltron/svg/tag.rb
@@ -27,13 +27,13 @@ module Voltron
         create_png if Voltron.config.svg.buildable?
       end
 
-      def image_path
-        # Get the fallback image path, either using the :fallback option if specified, or use the default generated png
-        asset_path (@options[:fallback] || name(:png, size.to_s.downcase, color.upcase))
+      def sass_svg_name
+        Sass::Script::String.new(name(@options[:extension], color.upcase), :string)
       end
 
-      def svg_path
-        asset_path name(@options[:extension], color.upcase)
+      def sass_image_name
+        # Get the fallback image path, either using the :fallback option if specified, or use the default generated png
+        Sass::Script::String.new((@options[:fallback] || name(:png, size.to_s.downcase, color.upcase)), :string)
       end
 
       def asset_path(filename)


### PR DESCRIPTION
We were trying to get the asset url manually using sprocket and actioncontroller helpers but the url generated by these helpers was not recognized by sprockets as a dependant link of css files and the svgs were not appended a digest while precompiling. This commit allows voltron-svg use sass helper methods to get svg url and this allows sprocket append a digest to svg urls.